### PR TITLE
Session 1

### DIFF
--- a/ios-training-komori/Base.lproj/Main.storyboard
+++ b/ios-training-komori/Base.lproj/Main.storyboard
@@ -3,6 +3,7 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -22,13 +23,33 @@
                                     <constraint firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="height" multiplier="1:1" id="1tJ-ye-KNq"/>
                                 </constraints>
                             </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WPO-22-TZ1" userLabel="Left Label">
+                                <rect key="frame" x="98.333333333333343" y="524.33333333333337" width="98.333333333333343" height="21"/>
+                                <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
+                                <color key="textColor" name="Blue"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hm5-yg-9cu" userLabel="Right Label">
+                                <rect key="frame" x="196.66666666666666" y="524.33333333333337" width="97.999999999999972" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" name="Red"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="sjz-7K-reb" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="2HH-do-cMb"/>
+                            <constraint firstItem="hm5-yg-9cu" firstAttribute="trailing" secondItem="sjz-7K-reb" secondAttribute="trailing" id="2gB-JF-B5Y"/>
+                            <constraint firstItem="WPO-22-TZ1" firstAttribute="trailing" secondItem="hm5-yg-9cu" secondAttribute="leading" id="B9s-py-JnA"/>
                             <constraint firstItem="sjz-7K-reb" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.5" id="Gln-iU-zu0"/>
+                            <constraint firstItem="hm5-yg-9cu" firstAttribute="leading" secondItem="WPO-22-TZ1" secondAttribute="trailing" id="MNI-Of-KsK"/>
+                            <constraint firstItem="WPO-22-TZ1" firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="width" multiplier="0.5" id="PUj-63-dgj"/>
+                            <constraint firstItem="hm5-yg-9cu" firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="width" multiplier="0.5" id="Pjn-hV-H2s"/>
+                            <constraint firstItem="hm5-yg-9cu" firstAttribute="top" secondItem="sjz-7K-reb" secondAttribute="bottom" id="XXt-AS-9dP"/>
                             <constraint firstItem="sjz-7K-reb" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="iw5-W8-RGn"/>
+                            <constraint firstItem="WPO-22-TZ1" firstAttribute="top" secondItem="sjz-7K-reb" secondAttribute="bottom" id="xbj-2G-342"/>
+                            <constraint firstItem="WPO-22-TZ1" firstAttribute="leading" secondItem="sjz-7K-reb" secondAttribute="leading" id="yGM-vA-n19"/>
                         </constraints>
                     </view>
                 </viewController>
@@ -38,6 +59,12 @@
         </scene>
     </scenes>
     <resources>
+        <namedColor name="Blue">
+            <color red="0.20499999821186066" green="0.53700000047683716" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="Red">
+            <color red="1" green="0.210999995470047" blue="0.15700000524520874" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/ios-training-komori/Base.lproj/Main.storyboard
+++ b/ios-training-komori/Base.lproj/Main.storyboard
@@ -26,7 +26,7 @@
                                             <constraint firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="height" multiplier="1:1" id="1tJ-ye-KNq"/>
                                         </constraints>
                                     </imageView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="edZ-P9-Ib9">
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="edZ-P9-Ib9">
                                         <rect key="frame" x="0.0" y="196.33333333333331" width="196.33333333333334" height="20.333333333333314"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WPO-22-TZ1" userLabel="Left Label">
@@ -44,10 +44,8 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="hm5-yg-9cu" secondAttribute="trailing" id="9Lj-9K-Bnr"/>
-                                            <constraint firstItem="hm5-yg-9cu" firstAttribute="width" secondItem="edZ-P9-Ib9" secondAttribute="width" multiplier="0.5" id="Bn4-eW-hOl"/>
                                             <constraint firstItem="hm5-yg-9cu" firstAttribute="leading" secondItem="WPO-22-TZ1" secondAttribute="trailing" id="HYb-mD-DhO"/>
                                             <constraint firstItem="WPO-22-TZ1" firstAttribute="trailing" secondItem="hm5-yg-9cu" secondAttribute="leading" id="fgT-VX-O9h"/>
-                                            <constraint firstItem="WPO-22-TZ1" firstAttribute="width" secondItem="edZ-P9-Ib9" secondAttribute="width" multiplier="0.5" id="ml5-Y3-GmY"/>
                                             <constraint firstItem="WPO-22-TZ1" firstAttribute="leading" secondItem="edZ-P9-Ib9" secondAttribute="leading" id="tV3-pP-hcn"/>
                                         </constraints>
                                     </stackView>

--- a/ios-training-komori/Base.lproj/Main.storyboard
+++ b/ios-training-komori/Base.lproj/Main.storyboard
@@ -1,24 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="ios_training_komori" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="sjz-7K-reb" userLabel="Weather Image">
+                                <rect key="frame" x="98.333333333333329" y="327.66666666666669" width="196.33333333333337" height="196.66666666666669"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="height" multiplier="1:1" id="1tJ-ye-KNq"/>
+                                </constraints>
+                            </imageView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="sjz-7K-reb" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="2HH-do-cMb"/>
+                            <constraint firstItem="sjz-7K-reb" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.5" id="Gln-iU-zu0"/>
+                            <constraint firstItem="sjz-7K-reb" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="iw5-W8-RGn"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="139" y="-2"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/ios-training-komori/Base.lproj/Main.storyboard
+++ b/ios-training-komori/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="TKr-E4-YZM">
-                                <rect key="frame" x="98.333333333333329" y="317.66666666666669" width="196.33333333333337" height="216.66666666666669"/>
+                                <rect key="frame" x="98.333333333333314" y="317.66666666666669" width="196.33333333333337" height="216.66666666666669"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="sjz-7K-reb" userLabel="Weather Image">
                                         <rect key="frame" x="0.0" y="0.0" width="196.33333333333334" height="196.33333333333334"/>
@@ -27,7 +27,7 @@
                                         </constraints>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="edZ-P9-Ib9">
-                                        <rect key="frame" x="0.0" y="196.33333333333331" width="196.33333333333334" height="20.333333333333343"/>
+                                        <rect key="frame" x="0.0" y="196.33333333333331" width="196.33333333333334" height="20.333333333333314"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WPO-22-TZ1" userLabel="Left Label">
                                                 <rect key="frame" x="0.0" y="0.0" width="98.333333333333329" height="20.333333333333332"/>
@@ -56,13 +56,27 @@
                                     <constraint firstItem="edZ-P9-Ib9" firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="width" id="aDj-0Y-E5f"/>
                                 </constraints>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aJc-5M-ydg" userLabel="Close Button">
+                                <rect key="frame" x="114" y="614.33333333333337" width="67" height="34.333333333333371"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Close"/>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dCK-6b-Yh1" userLabel="Reload Button">
+                                <rect key="frame" x="207.33333333333337" y="614.33333333333337" width="76.333333333333314" height="34.333333333333371"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Reload"/>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="dCK-6b-Yh1" firstAttribute="top" secondItem="TKr-E4-YZM" secondAttribute="bottom" constant="80" id="Mxx-EV-VYp"/>
                             <constraint firstItem="TKr-E4-YZM" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.5" id="NIc-mv-7TD"/>
+                            <constraint firstItem="dCK-6b-Yh1" firstAttribute="centerX" secondItem="hm5-yg-9cu" secondAttribute="centerX" id="Od8-ZF-3G5"/>
                             <constraint firstItem="TKr-E4-YZM" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Os9-LO-ESK"/>
                             <constraint firstItem="TKr-E4-YZM" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Xqq-y5-LSc"/>
+                            <constraint firstItem="aJc-5M-ydg" firstAttribute="centerX" secondItem="WPO-22-TZ1" secondAttribute="centerX" id="YNy-hl-ooD"/>
+                            <constraint firstItem="aJc-5M-ydg" firstAttribute="top" secondItem="TKr-E4-YZM" secondAttribute="bottom" constant="80" id="y1N-Qj-Fwl"/>
                         </constraints>
                     </view>
                 </viewController>

--- a/ios-training-komori/Base.lproj/Main.storyboard
+++ b/ios-training-komori/Base.lproj/Main.storyboard
@@ -17,39 +17,52 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="sjz-7K-reb" userLabel="Weather Image">
-                                <rect key="frame" x="98.333333333333329" y="327.66666666666669" width="196.33333333333337" height="196.66666666666669"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="TKr-E4-YZM">
+                                <rect key="frame" x="98.333333333333329" y="317.66666666666669" width="196.33333333333337" height="216.66666666666669"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="sjz-7K-reb" userLabel="Weather Image">
+                                        <rect key="frame" x="0.0" y="0.0" width="196.33333333333334" height="196.33333333333334"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="height" multiplier="1:1" id="1tJ-ye-KNq"/>
+                                        </constraints>
+                                    </imageView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="edZ-P9-Ib9">
+                                        <rect key="frame" x="0.0" y="196.33333333333331" width="196.33333333333334" height="20.333333333333343"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WPO-22-TZ1" userLabel="Left Label">
+                                                <rect key="frame" x="0.0" y="0.0" width="98.333333333333329" height="20.333333333333332"/>
+                                                <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
+                                                <color key="textColor" name="Blue"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hm5-yg-9cu" userLabel="Right Label">
+                                                <rect key="frame" x="98.333333333333314" y="0.0" width="98" height="20.333333333333332"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <color key="textColor" name="Red"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="hm5-yg-9cu" secondAttribute="trailing" id="9Lj-9K-Bnr"/>
+                                            <constraint firstItem="hm5-yg-9cu" firstAttribute="width" secondItem="edZ-P9-Ib9" secondAttribute="width" multiplier="0.5" id="Bn4-eW-hOl"/>
+                                            <constraint firstItem="hm5-yg-9cu" firstAttribute="leading" secondItem="WPO-22-TZ1" secondAttribute="trailing" id="HYb-mD-DhO"/>
+                                            <constraint firstItem="WPO-22-TZ1" firstAttribute="trailing" secondItem="hm5-yg-9cu" secondAttribute="leading" id="fgT-VX-O9h"/>
+                                            <constraint firstItem="WPO-22-TZ1" firstAttribute="width" secondItem="edZ-P9-Ib9" secondAttribute="width" multiplier="0.5" id="ml5-Y3-GmY"/>
+                                            <constraint firstItem="WPO-22-TZ1" firstAttribute="leading" secondItem="edZ-P9-Ib9" secondAttribute="leading" id="tV3-pP-hcn"/>
+                                        </constraints>
+                                    </stackView>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="height" multiplier="1:1" id="1tJ-ye-KNq"/>
+                                    <constraint firstItem="edZ-P9-Ib9" firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="width" id="aDj-0Y-E5f"/>
                                 </constraints>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WPO-22-TZ1" userLabel="Left Label">
-                                <rect key="frame" x="98.333333333333343" y="524.33333333333337" width="98.333333333333343" height="21"/>
-                                <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
-                                <color key="textColor" name="Blue"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hm5-yg-9cu" userLabel="Right Label">
-                                <rect key="frame" x="196.66666666666666" y="524.33333333333337" width="97.999999999999972" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" name="Red"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="sjz-7K-reb" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="2HH-do-cMb"/>
-                            <constraint firstItem="hm5-yg-9cu" firstAttribute="trailing" secondItem="sjz-7K-reb" secondAttribute="trailing" id="2gB-JF-B5Y"/>
-                            <constraint firstItem="WPO-22-TZ1" firstAttribute="trailing" secondItem="hm5-yg-9cu" secondAttribute="leading" id="B9s-py-JnA"/>
-                            <constraint firstItem="sjz-7K-reb" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.5" id="Gln-iU-zu0"/>
-                            <constraint firstItem="hm5-yg-9cu" firstAttribute="leading" secondItem="WPO-22-TZ1" secondAttribute="trailing" id="MNI-Of-KsK"/>
-                            <constraint firstItem="WPO-22-TZ1" firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="width" multiplier="0.5" id="PUj-63-dgj"/>
-                            <constraint firstItem="hm5-yg-9cu" firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="width" multiplier="0.5" id="Pjn-hV-H2s"/>
-                            <constraint firstItem="hm5-yg-9cu" firstAttribute="top" secondItem="sjz-7K-reb" secondAttribute="bottom" id="XXt-AS-9dP"/>
-                            <constraint firstItem="sjz-7K-reb" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="iw5-W8-RGn"/>
-                            <constraint firstItem="WPO-22-TZ1" firstAttribute="top" secondItem="sjz-7K-reb" secondAttribute="bottom" id="xbj-2G-342"/>
-                            <constraint firstItem="WPO-22-TZ1" firstAttribute="leading" secondItem="sjz-7K-reb" secondAttribute="leading" id="yGM-vA-n19"/>
+                            <constraint firstItem="TKr-E4-YZM" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.5" id="NIc-mv-7TD"/>
+                            <constraint firstItem="TKr-E4-YZM" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Os9-LO-ESK"/>
+                            <constraint firstItem="TKr-E4-YZM" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Xqq-y5-LSc"/>
                         </constraints>
                     </view>
                 </viewController>

--- a/ios-training-komori/Base.lproj/Main.storyboard
+++ b/ios-training-komori/Base.lproj/Main.storyboard
@@ -50,9 +50,6 @@
                                         </constraints>
                                     </stackView>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="edZ-P9-Ib9" firstAttribute="width" secondItem="sjz-7K-reb" secondAttribute="width" id="aDj-0Y-E5f"/>
-                                </constraints>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aJc-5M-ydg" userLabel="Close Button">
                                 <rect key="frame" x="114" y="614.33333333333337" width="67" height="34.333333333333371"/>


### PR DESCRIPTION
## 修正内容
[Session 1](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/AutoLayout.md)を実装しました。

AutoLayoutで以下を追加
- UIImage
- UILabel x 2
- UIButton x 2


## スクリーンショット
| iPhone 15 Pro | iPad Pro 11″ |
|-----------|-----------|
| <img src="https://github.com/yumemi-inc/ios-training-komori/assets/50921804/71f13155-0062-460c-a25d-2449a078f7ed" /> | <img src="https://github.com/yumemi-inc/ios-training-komori/assets/50921804/3c9fa921-415f-4406-8bd8-5baa1df5e00f" /> |

