### PR TITLE
Session 7: NotificationCenter

### DIFF
--- a/ios-training-komori/View/Weather/WeatherViewController.swift
+++ b/ios-training-komori/View/Weather/WeatherViewController.swift
@@ -61,6 +61,7 @@ private extension WeatherViewController {
     }
 
     @objc func handleForegroundTransition() {
+        dismissPresentedAlert()
         reload()
     }
 }
@@ -112,6 +113,12 @@ private extension WeatherViewController {
         alertController.addAction(closeAction)
 
         present(alertController, animated: true)
+    }
+
+    func dismissPresentedAlert() {
+        if let alertController = presentedViewController as? UIAlertController {
+            alertController.dismiss(animated: true)
+        }
     }
 }
 

--- a/ios-training-komori/View/Weather/WeatherViewController.swift
+++ b/ios-training-komori/View/Weather/WeatherViewController.swift
@@ -25,10 +25,6 @@ class WeatherViewController: UIViewController {
         setupDataBindingsAndObservers()
     }
 
-    deinit {
-        removeObservers()
-    }
-
     @IBAction func onCloseButtonTapped(_ sender: Any) {
         dismiss(animated: true)
     }
@@ -57,16 +53,15 @@ private extension WeatherViewController {
             .store(in: &subscriptions)
 
         NotificationCenter.default.addObserver(
-            forName: UIApplication.willEnterForegroundNotification,
-            object: nil,
-            queue: OperationQueue.main
-        ) { [weak self] _ in
-            self?.reload()
-        }
+            self,
+            selector: #selector(handleForegroundTransition),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
     }
 
-    func removeObservers() {
-        NotificationCenter.default.removeObserver(self)
+    @objc func handleForegroundTransition() {
+        reload()
     }
 }
 

--- a/ios-training-komori/View/Weather/WeatherViewController.swift
+++ b/ios-training-komori/View/Weather/WeatherViewController.swift
@@ -25,12 +25,16 @@ class WeatherViewController: UIViewController {
         setupSubscriptions()
     }
 
+    deinit {
+        removeObservers()
+    }
+
     @IBAction func onCloseButtonTapped(_ sender: Any) {
         dismiss(animated: true)
     }
 
     @IBAction func onReloadButtonTapped(_ sender: Any) {
-        weatherModel.fetch(area: area, date: Date())
+        reload()
     }
 }
 
@@ -51,6 +55,18 @@ private extension WeatherViewController {
                 self?.showAlert(for: error)
             }
             .store(in: &subscriptions)
+
+        NotificationCenter.default.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: OperationQueue.main
+        ) { [weak self] _ in
+            self?.reload()
+        }
+    }
+
+    func removeObservers() {
+        NotificationCenter.default.removeObserver(self)
     }
 }
 
@@ -132,5 +148,12 @@ private extension WeatherViewController {
         }
 
         return message
+    }
+}
+
+// MARK: - Data Management
+private extension WeatherViewController {
+    func reload() {
+        weatherModel.fetch(area: area, date: Date())
     }
 }

--- a/ios-training-komori/View/Weather/WeatherViewController.swift
+++ b/ios-training-komori/View/Weather/WeatherViewController.swift
@@ -22,7 +22,7 @@ class WeatherViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setupSubscriptions()
+        setupDataBindingsAndObservers()
     }
 
     deinit {
@@ -38,10 +38,10 @@ class WeatherViewController: UIViewController {
     }
 }
 
-// MARK: - Observers
+// MARK: - Data Bindings and Observers
 private extension WeatherViewController {
 
-    func setupSubscriptions() {
+    func setupDataBindingsAndObservers() {
         weatherModel.$weather
             .sink { [weak self] weather in
                 if let weather {


### PR DESCRIPTION
[Session 7: NotificationCenter](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/NotificationCenter.md)の実装です。

## 修正内容
- アプリがフォアグラウンドに来たタイミングの通知（`UIApplication.willEnterForegroundNotification`）を監視し、通知を受けたら天気予報を更新するようにする


## スクリーンショット
<img src="https://github.com/yumemi-inc/ios-training-komori/assets/50921804/ab919e79-bedd-41c5-b500-38a8bbbf362d" height="600" />