### PR TITLE
Session 9: ThreadBlock

### DIFF
--- a/ios-training-komori/Model/WeatherModel.swift
+++ b/ios-training-komori/Model/WeatherModel.swift
@@ -31,14 +31,16 @@ final class WeatherModel: WeatherProvider {
     }
 
     func fetch(area: String, date: Date) {
-        do {
-            let requestJson = try encodeRequest(area: area, date: date)
-            let responseJson = try YumemiWeather.fetchWeather(requestJson)
-            let weather = try decodeResponse(responseJson)
+        DispatchQueue.global().async { [self] in
+            do {
+                let requestJson = try encodeRequest(area: area, date: date)
+                let responseJson = try YumemiWeather.syncFetchWeather(requestJson)
+                let fetchedWeather = try decodeResponse(responseJson)
 
-            self.weather = weather
-        } catch {
-            errorSubject.send(error)
+                weather = fetchedWeather
+            } catch {
+                errorSubject.send(error)
+            }
         }
     }
 }

--- a/ios-training-komori/View/Weather/Base.lproj/WeatherScreen.storyboard
+++ b/ios-training-komori/View/Weather/Base.lproj/WeatherScreen.storyboard
@@ -91,6 +91,7 @@
                         <outlet property="loadingIndicator" destination="LB4-0j-fiS" id="jUb-Xi-4ha"/>
                         <outlet property="maxTemperatureLabel" destination="hm5-yg-9cu" id="nRK-aS-4wH"/>
                         <outlet property="minTemperatureLabel" destination="WPO-22-TZ1" id="wqT-Pi-ll6"/>
+                        <outlet property="reloadButton" destination="dCK-6b-Yh1" id="lyq-83-wJg"/>
                         <outlet property="weatherImage" destination="sjz-7K-reb" id="9pW-5V-5RH"/>
                     </connections>
                 </viewController>

--- a/ios-training-komori/View/Weather/Base.lproj/WeatherScreen.storyboard
+++ b/ios-training-komori/View/Weather/Base.lproj/WeatherScreen.storyboard
@@ -51,6 +51,9 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="LB4-0j-fiS">
+                                <rect key="frame" x="186.66666666666666" y="534.33333333333337" width="20" height="80"/>
+                            </activityIndicatorView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aJc-5M-ydg" userLabel="Close Button">
                                 <rect key="frame" x="114" y="614.33333333333337" width="67" height="34.333333333333371"/>
                                 <state key="normal" title="Button"/>
@@ -71,17 +74,21 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="LB4-0j-fiS" firstAttribute="bottom" secondItem="aJc-5M-ydg" secondAttribute="top" id="Kq5-Er-U41"/>
                             <constraint firstItem="dCK-6b-Yh1" firstAttribute="top" secondItem="TKr-E4-YZM" secondAttribute="bottom" constant="80" id="Mxx-EV-VYp"/>
                             <constraint firstItem="TKr-E4-YZM" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="0.5" id="NIc-mv-7TD"/>
                             <constraint firstItem="dCK-6b-Yh1" firstAttribute="centerX" secondItem="hm5-yg-9cu" secondAttribute="centerX" id="Od8-ZF-3G5"/>
                             <constraint firstItem="TKr-E4-YZM" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Os9-LO-ESK"/>
                             <constraint firstItem="TKr-E4-YZM" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Xqq-y5-LSc"/>
                             <constraint firstItem="aJc-5M-ydg" firstAttribute="centerX" secondItem="WPO-22-TZ1" secondAttribute="centerX" id="YNy-hl-ooD"/>
+                            <constraint firstItem="LB4-0j-fiS" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="YZP-pO-zbz"/>
+                            <constraint firstItem="LB4-0j-fiS" firstAttribute="top" secondItem="TKr-E4-YZM" secondAttribute="bottom" id="mn6-YD-7Xe"/>
                             <constraint firstItem="aJc-5M-ydg" firstAttribute="top" secondItem="TKr-E4-YZM" secondAttribute="bottom" constant="80" id="y1N-Qj-Fwl"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="ubu-mu-Gnr"/>
                     <connections>
+                        <outlet property="loadingIndicator" destination="LB4-0j-fiS" id="jUb-Xi-4ha"/>
                         <outlet property="maxTemperatureLabel" destination="hm5-yg-9cu" id="nRK-aS-4wH"/>
                         <outlet property="minTemperatureLabel" destination="WPO-22-TZ1" id="wqT-Pi-ll6"/>
                         <outlet property="weatherImage" destination="sjz-7K-reb" id="9pW-5V-5RH"/>

--- a/ios-training-komori/View/Weather/WeatherViewController.swift
+++ b/ios-training-komori/View/Weather/WeatherViewController.swift
@@ -18,6 +18,7 @@ final class WeatherViewController: UIViewController {
     @IBOutlet @ViewLoading var weatherImage: UIImageView
     @IBOutlet @ViewLoading var minTemperatureLabel: UILabel
     @IBOutlet @ViewLoading var maxTemperatureLabel: UILabel
+    @IBOutlet @ViewLoading var loadingIndicator: UIActivityIndicatorView
 
     init?(
         coder: NSCoder,
@@ -56,6 +57,7 @@ private extension WeatherViewController {
                 if let weather {
                     self?.updateViews(with: weather)
                 }
+                self?.loadingIndicator.stopAnimating()
             }
             .store(in: &subscriptions)
 
@@ -63,6 +65,7 @@ private extension WeatherViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
                 self?.showAlert(for: error)
+                self?.loadingIndicator.stopAnimating()
             }
             .store(in: &subscriptions)
 
@@ -173,6 +176,7 @@ private extension WeatherViewController {
 // MARK: - Data Management
 private extension WeatherViewController {
     func reload() {
+        loadingIndicator.startAnimating()
         weatherProvider.fetch(area: area, date: Date())
     }
 }

--- a/ios-training-komori/View/Weather/WeatherViewController.swift
+++ b/ios-training-komori/View/Weather/WeatherViewController.swift
@@ -19,6 +19,7 @@ final class WeatherViewController: UIViewController {
     @IBOutlet @ViewLoading var minTemperatureLabel: UILabel
     @IBOutlet @ViewLoading var maxTemperatureLabel: UILabel
     @IBOutlet @ViewLoading var loadingIndicator: UIActivityIndicatorView
+    @IBOutlet @ViewLoading var reloadButton: UIButton
 
     init?(
         coder: NSCoder,
@@ -57,7 +58,7 @@ private extension WeatherViewController {
                 if let weather {
                     self?.updateViews(with: weather)
                 }
-                self?.loadingIndicator.stopAnimating()
+                self?.stopLoadingIndicator()
             }
             .store(in: &subscriptions)
 
@@ -65,7 +66,7 @@ private extension WeatherViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
                 self?.showAlert(for: error)
-                self?.loadingIndicator.stopAnimating()
+                self?.stopLoadingIndicator()
             }
             .store(in: &subscriptions)
 
@@ -140,6 +141,16 @@ private extension WeatherViewController {
             completion?()
         }
     }
+
+    func startLoadingIndicator() {
+        loadingIndicator.startAnimating()
+        reloadButton.isEnabled = false
+    }
+
+    func stopLoadingIndicator() {
+        loadingIndicator.stopAnimating()
+        reloadButton.isEnabled = true
+    }
 }
 
 // MARK: - UI Utilities
@@ -176,7 +187,7 @@ private extension WeatherViewController {
 // MARK: - Data Management
 private extension WeatherViewController {
     func reload() {
-        loadingIndicator.startAnimating()
+        startLoadingIndicator()
         weatherProvider.fetch(area: area, date: Date())
     }
 }

--- a/ios-training-komori/View/Weather/WeatherViewController.swift
+++ b/ios-training-komori/View/Weather/WeatherViewController.swift
@@ -51,6 +51,7 @@ private extension WeatherViewController {
 
     func setupDataBindingsAndObservers() {
         weatherProvider.weatherPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] weather in
                 if let weather {
                     self?.updateViews(with: weather)
@@ -59,6 +60,7 @@ private extension WeatherViewController {
             .store(in: &subscriptions)
 
         weatherProvider.errorPublisher
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
                 self?.showAlert(for: error)
             }

--- a/ios-training-komoriTests/WeatherViewControllerTests.swift
+++ b/ios-training-komoriTests/WeatherViewControllerTests.swift
@@ -74,7 +74,12 @@ final class WeatherViewControllerTests: XCTestCase {
         weatherSubject.send(weather)
 
         // Then
-        XCTAssertEqual(weatherViewController.weatherImage.image, UIImage(named: "img_sunny"))
+        let expectation = XCTestExpectation(description: "Weather image should be updated to 'img_sunny")
+        DispatchQueue.main.async {
+            XCTAssertEqual(self.weatherViewController.weatherImage.image, UIImage(named: "img_sunny"))
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
     }
 
     func testCloudyImageIsSetIfCloudy() {
@@ -98,7 +103,12 @@ final class WeatherViewControllerTests: XCTestCase {
         weatherSubject.send(weather)
 
         // Then
-        XCTAssertEqual(weatherViewController.weatherImage.image, UIImage(named: "img_cloudy"))
+        let expectation = XCTestExpectation(description: "Weather image should be updated to 'img_cloudy")
+        DispatchQueue.main.async {
+            XCTAssertEqual(self.weatherViewController.weatherImage.image, UIImage(named: "img_cloudy"))
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
     }
 
     func testRainyImageIsSetIfRainy() {
@@ -122,7 +132,12 @@ final class WeatherViewControllerTests: XCTestCase {
         weatherSubject.send(weather)
 
         // Then
-        XCTAssertEqual(weatherViewController.weatherImage.image, UIImage(named: "img_rainy"))
+        let expectation = XCTestExpectation(description: "Weather image should be updated to 'img_rainy")
+        DispatchQueue.main.async {
+            XCTAssertEqual(self.weatherViewController.weatherImage.image, UIImage(named: "img_rainy"))
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
     }
 
     func testTemperatureLabelsAreCorrectlySet() {
@@ -146,7 +161,12 @@ final class WeatherViewControllerTests: XCTestCase {
         weatherSubject.send(weather)
 
         // Then
-        XCTAssertEqual(weatherViewController.minTemperatureLabel.text, "-10")
-        XCTAssertEqual(weatherViewController.maxTemperatureLabel.text, "10")
+        let expectation = XCTestExpectation(description: "Temperature labels should be updated to -10 / 10")
+        DispatchQueue.main.async {
+            XCTAssertEqual(self.weatherViewController.minTemperatureLabel.text, "-10")
+            XCTAssertEqual(self.weatherViewController.maxTemperatureLabel.text, "10")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
     }
 }


### PR DESCRIPTION
[Session 9: ThreadBlock](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/ThreadBlock.md)の実装です。

## 修正内容
- 呼び出しAPIを `Sync ver` に変更
- 天気予報の取得処理が完了するまで UIActivityIndicatorView を表示
- テストを修正（非同期に対応）
- ローディング中はリロードボタンを非活性化

## スクリーンショット
<img src="https://github.com/yumemi-inc/ios-training-komori/assets/50921804/d2acea16-f3b5-4a29-9c55-d74290b5e017" height="600" />
