### PR TITLE
Session/10: Delegate

### DIFF
--- a/ios-training-komori/View/Weather/WeatherViewController.swift
+++ b/ios-training-komori/View/Weather/WeatherViewController.swift
@@ -6,13 +6,11 @@
 //
 
 import UIKit
-import Combine
 import YumemiWeather
 
 final class WeatherViewController: UIViewController {
 
-    private let weatherProvider: WeatherProvider
-    private var subscriptions = Set<AnyCancellable>()
+    private var weatherProvider: WeatherProvider
     private let area = "tokyo"
 
     @IBOutlet @ViewLoading var weatherImage: UIImageView
@@ -36,6 +34,8 @@ final class WeatherViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        weatherProvider.delegate = self
+
         setupDataBindingsAndObservers()
     }
 
@@ -52,24 +52,6 @@ final class WeatherViewController: UIViewController {
 private extension WeatherViewController {
 
     func setupDataBindingsAndObservers() {
-        weatherProvider.weatherPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] weather in
-                if let weather {
-                    self?.updateViews(with: weather)
-                }
-                self?.stopLoadingIndicator()
-            }
-            .store(in: &subscriptions)
-
-        weatherProvider.errorPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] error in
-                self?.showAlert(for: error)
-                self?.stopLoadingIndicator()
-            }
-            .store(in: &subscriptions)
-
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleForegroundTransition),
@@ -189,5 +171,23 @@ private extension WeatherViewController {
     func reload() {
         startLoadingIndicator()
         weatherProvider.fetch(area: area, date: Date())
+    }
+}
+
+// MARK: - WeatherProviderDelegate
+extension WeatherViewController: WeatherProviderDelegate {
+
+    func weatherProvider(_ weatherProvider: WeatherProvider, didUpdateWeather weather: Weather) {
+        DispatchQueue.main.async {
+            self.updateViews(with: weather)
+            self.stopLoadingIndicator()
+        }
+    }
+
+    func weatherProvider(_ weatherProvider: WeatherProvider, didReceiveError error: Error) {
+        DispatchQueue.main.async {
+            self.showAlert(for: error)
+            self.stopLoadingIndicator()
+        }
     }
 }

--- a/ios-training-komori/View/Weather/WeatherViewController.swift
+++ b/ios-training-komori/View/Weather/WeatherViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import OSLog
 import YumemiWeather
 
 final class WeatherViewController: UIViewController {
@@ -37,6 +38,10 @@ final class WeatherViewController: UIViewController {
         weatherProvider.delegate = self
 
         setupDataBindingsAndObservers()
+    }
+
+    deinit {
+        Logger().debug("deinit")
     }
 
     @IBAction func onCloseButtonTapped(_ sender: Any) {

--- a/ios-training-komoriTests/GeneratedMocks.swift
+++ b/ios-training-komoriTests/GeneratedMocks.swift
@@ -7,7 +7,6 @@
 import Cuckoo
 @testable import ios_training_komori
 
-import Combine
 import Foundation
 import YumemiWeather
 
@@ -38,30 +37,24 @@ import YumemiWeather
     
     
     
-     var weatherPublisher: AnyPublisher<Weather?, Never> {
+     var delegate: WeatherProviderDelegate? {
         get {
-            return cuckoo_manager.getter("weatherPublisher",
+            return cuckoo_manager.getter("delegate",
                 superclassCall:
                     
                     Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                     ,
-                defaultCall:  __defaultImplStub!.weatherPublisher)
+                defaultCall:  __defaultImplStub!.delegate)
         }
         
-    }
-    
-    
-    
-    
-    
-     var errorPublisher: AnyPublisher<Error, Never> {
-        get {
-            return cuckoo_manager.getter("errorPublisher",
+        set {
+            cuckoo_manager.setter("delegate",
+                value: newValue,
                 superclassCall:
                     
                     Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                     ,
-                defaultCall:  __defaultImplStub!.errorPublisher)
+                defaultCall: __defaultImplStub!.delegate = newValue)
         }
         
     }
@@ -101,15 +94,8 @@ import YumemiWeather
         
         
         
-        var weatherPublisher: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWeatherProvider, AnyPublisher<Weather?, Never>> {
-            return .init(manager: cuckoo_manager, name: "weatherPublisher")
-        }
-        
-        
-        
-        
-        var errorPublisher: Cuckoo.ProtocolToBeStubbedReadOnlyProperty<MockWeatherProvider, AnyPublisher<Error, Never>> {
-            return .init(manager: cuckoo_manager, name: "errorPublisher")
+        var delegate: Cuckoo.ProtocolToBeStubbedOptionalProperty<MockWeatherProvider, WeatherProviderDelegate> {
+            return .init(manager: cuckoo_manager, name: "delegate")
         }
         
         
@@ -141,15 +127,8 @@ import YumemiWeather
         
         
         
-        var weatherPublisher: Cuckoo.VerifyReadOnlyProperty<AnyPublisher<Weather?, Never>> {
-            return .init(manager: cuckoo_manager, name: "weatherPublisher", callMatcher: callMatcher, sourceLocation: sourceLocation)
-        }
-        
-        
-        
-        
-        var errorPublisher: Cuckoo.VerifyReadOnlyProperty<AnyPublisher<Error, Never>> {
-            return .init(manager: cuckoo_manager, name: "errorPublisher", callMatcher: callMatcher, sourceLocation: sourceLocation)
+        var delegate: Cuckoo.VerifyOptionalProperty<WeatherProviderDelegate> {
+            return .init(manager: cuckoo_manager, name: "delegate", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
         
@@ -176,21 +155,12 @@ import YumemiWeather
     
     
     
-     var weatherPublisher: AnyPublisher<Weather?, Never> {
+     var delegate: WeatherProviderDelegate? {
         get {
-            return DefaultValueRegistry.defaultValue(for: (AnyPublisher<Weather?, Never>).self)
+            return DefaultValueRegistry.defaultValue(for: (WeatherProviderDelegate?).self)
         }
         
-    }
-    
-    
-    
-    
-    
-     var errorPublisher: AnyPublisher<Error, Never> {
-        get {
-            return DefaultValueRegistry.defaultValue(for: (AnyPublisher<Error, Never>).self)
-        }
+        set { }
         
     }
     
@@ -203,6 +173,177 @@ import YumemiWeather
     
     
      func fetch(area: String, date: Date)   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+    
+}
+
+
+
+
+
+
+
+
+
+
+ class MockWeatherProviderDelegate: WeatherProviderDelegate, Cuckoo.ProtocolMock {
+    
+     typealias MocksType = WeatherProviderDelegate
+    
+     typealias Stubbing = __StubbingProxy_WeatherProviderDelegate
+     typealias Verification = __VerificationProxy_WeatherProviderDelegate
+
+     let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: false)
+
+    
+    private var __defaultImplStub: WeatherProviderDelegate?
+
+     func enableDefaultImplementation(_ stub: WeatherProviderDelegate) {
+        __defaultImplStub = stub
+        cuckoo_manager.enableDefaultStubImplementation()
+    }
+    
+
+    
+
+    
+
+    
+    
+    
+    
+     func weatherProvider(_ weatherProvider: WeatherProvider, didUpdateWeather weather: Weather)  {
+        
+    return cuckoo_manager.call(
+    """
+    weatherProvider(_: WeatherProvider, didUpdateWeather: Weather)
+    """,
+            parameters: (weatherProvider, weather),
+            escapingParameters: (weatherProvider, weather),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.weatherProvider(weatherProvider, didUpdateWeather: weather))
+        
+    }
+    
+    
+    
+    
+    
+     func weatherProvider(_ weatherProvider: WeatherProvider, didReceiveError error: Error)  {
+        
+    return cuckoo_manager.call(
+    """
+    weatherProvider(_: WeatherProvider, didReceiveError: Error)
+    """,
+            parameters: (weatherProvider, error),
+            escapingParameters: (weatherProvider, error),
+            superclassCall:
+                
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                ,
+            defaultCall: __defaultImplStub!.weatherProvider(weatherProvider, didReceiveError: error))
+        
+    }
+    
+    
+
+     struct __StubbingProxy_WeatherProviderDelegate: Cuckoo.StubbingProxy {
+        private let cuckoo_manager: Cuckoo.MockManager
+    
+         init(manager: Cuckoo.MockManager) {
+            self.cuckoo_manager = manager
+        }
+        
+        
+        
+        
+        func weatherProvider<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(_ weatherProvider: M1, didUpdateWeather weather: M2) -> Cuckoo.ProtocolStubNoReturnFunction<(WeatherProvider, Weather)> where M1.MatchedType == WeatherProvider, M2.MatchedType == Weather {
+            let matchers: [Cuckoo.ParameterMatcher<(WeatherProvider, Weather)>] = [wrap(matchable: weatherProvider) { $0.0 }, wrap(matchable: weather) { $0.1 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWeatherProviderDelegate.self, method:
+    """
+    weatherProvider(_: WeatherProvider, didUpdateWeather: Weather)
+    """, parameterMatchers: matchers))
+        }
+        
+        
+        
+        
+        func weatherProvider<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(_ weatherProvider: M1, didReceiveError error: M2) -> Cuckoo.ProtocolStubNoReturnFunction<(WeatherProvider, Error)> where M1.MatchedType == WeatherProvider, M2.MatchedType == Error {
+            let matchers: [Cuckoo.ParameterMatcher<(WeatherProvider, Error)>] = [wrap(matchable: weatherProvider) { $0.0 }, wrap(matchable: error) { $0.1 }]
+            return .init(stub: cuckoo_manager.createStub(for: MockWeatherProviderDelegate.self, method:
+    """
+    weatherProvider(_: WeatherProvider, didReceiveError: Error)
+    """, parameterMatchers: matchers))
+        }
+        
+        
+    }
+
+     struct __VerificationProxy_WeatherProviderDelegate: Cuckoo.VerificationProxy {
+        private let cuckoo_manager: Cuckoo.MockManager
+        private let callMatcher: Cuckoo.CallMatcher
+        private let sourceLocation: Cuckoo.SourceLocation
+    
+         init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+            self.cuckoo_manager = manager
+            self.callMatcher = callMatcher
+            self.sourceLocation = sourceLocation
+        }
+    
+        
+    
+        
+        
+        
+        @discardableResult
+        func weatherProvider<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(_ weatherProvider: M1, didUpdateWeather weather: M2) -> Cuckoo.__DoNotUse<(WeatherProvider, Weather), Void> where M1.MatchedType == WeatherProvider, M2.MatchedType == Weather {
+            let matchers: [Cuckoo.ParameterMatcher<(WeatherProvider, Weather)>] = [wrap(matchable: weatherProvider) { $0.0 }, wrap(matchable: weather) { $0.1 }]
+            return cuckoo_manager.verify(
+    """
+    weatherProvider(_: WeatherProvider, didUpdateWeather: Weather)
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+        
+        
+        @discardableResult
+        func weatherProvider<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(_ weatherProvider: M1, didReceiveError error: M2) -> Cuckoo.__DoNotUse<(WeatherProvider, Error), Void> where M1.MatchedType == WeatherProvider, M2.MatchedType == Error {
+            let matchers: [Cuckoo.ParameterMatcher<(WeatherProvider, Error)>] = [wrap(matchable: weatherProvider) { $0.0 }, wrap(matchable: error) { $0.1 }]
+            return cuckoo_manager.verify(
+    """
+    weatherProvider(_: WeatherProvider, didReceiveError: Error)
+    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        }
+        
+        
+    }
+}
+
+
+ class WeatherProviderDelegateStub: WeatherProviderDelegate {
+    
+
+    
+
+    
+    
+    
+    
+     func weatherProvider(_ weatherProvider: WeatherProvider, didUpdateWeather weather: Weather)   {
+        return DefaultValueRegistry.defaultValue(for: (Void).self)
+    }
+    
+    
+    
+    
+    
+     func weatherProvider(_ weatherProvider: WeatherProvider, didReceiveError error: Error)   {
         return DefaultValueRegistry.defaultValue(for: (Void).self)
     }
     

--- a/ios-training-komoriTests/WeatherViewControllerTests.swift
+++ b/ios-training-komoriTests/WeatherViewControllerTests.swift
@@ -7,16 +7,23 @@
 
 import XCTest
 import Cuckoo
-import Combine
 @testable import ios_training_komori
 
 final class WeatherViewControllerTests: XCTestCase {
 
     private var mockWeatherProvider: MockWeatherProvider!
+    private var weatherProviderDelegate: WeatherProviderDelegate!
     private var weatherViewController: WeatherViewController!
 
     override func setUpWithError() throws {
         self.mockWeatherProvider = MockWeatherProvider()
+
+        stub(mockWeatherProvider) { stub in
+            when(stub.delegate.get).thenReturn(self.weatherProviderDelegate)
+            when(stub.delegate.set(any())).then { delegate in
+                self.weatherProviderDelegate = delegate
+            }
+        }
 
         let storyboard = UIStoryboard(name: "WeatherScreen", bundle: nil)
         weatherViewController = storyboard.instantiateViewController(identifier: "weatherViewController") { coder in
@@ -29,19 +36,13 @@ final class WeatherViewControllerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         mockWeatherProvider = nil
+        weatherProviderDelegate = nil
         weatherViewController = nil
     }
 
     func testWeatherGetsReloadedOnReloadButtonTapped() {
         // Given
         stub(mockWeatherProvider) { stub in
-            let weatherSubject = CurrentValueSubject<Weather?, Never>(nil)
-            let weatherPublisher = weatherSubject.eraseToAnyPublisher()
-            when(stub.weatherPublisher.get).thenReturn(weatherPublisher)
-
-            let errorPublisher: AnyPublisher<Error, Never> = Empty().eraseToAnyPublisher()
-            when(stub.errorPublisher.get).thenReturn(errorPublisher)
-
             when(stub.fetch(area: any(), date: any())).thenDoNothing()
         }
 
@@ -55,23 +56,15 @@ final class WeatherViewControllerTests: XCTestCase {
 
     func testSunnyImageIsSetIfSunny() {
         // Given
-        let weatherSubject = CurrentValueSubject<Weather?, Never>(nil)
         let weather = Weather(
             condition: .sunny,
             minTemperature: 0,
             maxTemperature: 0
         )
-        stub(mockWeatherProvider) { stub in
-            let weatherPublisher = weatherSubject.eraseToAnyPublisher()
-            when(stub.weatherPublisher.get).thenReturn(weatherPublisher)
-
-            let errorPublisher: AnyPublisher<Error, Never> = Empty().eraseToAnyPublisher()
-            when(stub.errorPublisher.get).thenReturn(errorPublisher)
-        }
 
         // When
         weatherViewController.loadViewIfNeeded()
-        weatherSubject.send(weather)
+        weatherProviderDelegate.weatherProvider(self.mockWeatherProvider, didUpdateWeather: weather)
 
         // Then
         let expectation = XCTestExpectation(description: "Weather image should be updated to 'img_sunny")
@@ -84,23 +77,15 @@ final class WeatherViewControllerTests: XCTestCase {
 
     func testCloudyImageIsSetIfCloudy() {
         // Given
-        let weatherSubject = CurrentValueSubject<Weather?, Never>(nil)
         let weather = Weather(
             condition: .cloudy,
             minTemperature: 0,
             maxTemperature: 0
         )
-        stub(mockWeatherProvider) { stub in
-            let weatherPublisher = weatherSubject.eraseToAnyPublisher()
-            when(stub.weatherPublisher.get).thenReturn(weatherPublisher)
-
-            let errorPublisher: AnyPublisher<Error, Never> = Empty().eraseToAnyPublisher()
-            when(stub.errorPublisher.get).thenReturn(errorPublisher)
-        }
 
         // When
         weatherViewController.loadViewIfNeeded()
-        weatherSubject.send(weather)
+        weatherProviderDelegate.weatherProvider(self.mockWeatherProvider, didUpdateWeather: weather)
 
         // Then
         let expectation = XCTestExpectation(description: "Weather image should be updated to 'img_cloudy")
@@ -113,23 +98,15 @@ final class WeatherViewControllerTests: XCTestCase {
 
     func testRainyImageIsSetIfRainy() {
         // Given
-        let weatherSubject = CurrentValueSubject<Weather?, Never>(nil)
         let weather = Weather(
             condition: .rainy,
             minTemperature: 0,
             maxTemperature: 0
         )
-        stub(mockWeatherProvider) { stub in
-            let weatherPublisher = weatherSubject.eraseToAnyPublisher()
-            when(stub.weatherPublisher.get).thenReturn(weatherPublisher)
-
-            let errorPublisher: AnyPublisher<Error, Never> = Empty().eraseToAnyPublisher()
-            when(stub.errorPublisher.get).thenReturn(errorPublisher)
-        }
 
         // When
         weatherViewController.loadViewIfNeeded()
-        weatherSubject.send(weather)
+        weatherProviderDelegate.weatherProvider(self.mockWeatherProvider, didUpdateWeather: weather)
 
         // Then
         let expectation = XCTestExpectation(description: "Weather image should be updated to 'img_rainy")
@@ -142,23 +119,15 @@ final class WeatherViewControllerTests: XCTestCase {
 
     func testTemperatureLabelsAreCorrectlySet() {
         // Given
-        let weatherSubject = CurrentValueSubject<Weather?, Never>(nil)
         let weather = Weather(
             condition: .sunny,
             minTemperature: -10,
             maxTemperature: 10
         )
-        stub(mockWeatherProvider) { stub in
-            let weatherPublisher = weatherSubject.eraseToAnyPublisher()
-            when(stub.weatherPublisher.get).thenReturn(weatherPublisher)
-
-            let errorPublisher: AnyPublisher<Error, Never> = Empty().eraseToAnyPublisher()
-            when(stub.errorPublisher.get).thenReturn(errorPublisher)
-        }
 
         // When
         weatherViewController.loadViewIfNeeded()
-        weatherSubject.send(weather)
+        weatherProviderDelegate.weatherProvider(self.mockWeatherProvider, didUpdateWeather: weather)
 
         // Then
         let expectation = XCTestExpectation(description: "Temperature labels should be updated to -10 / 10")


### PR DESCRIPTION
[Session/10: Delegate](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Delegate.md)の実装です。

## 修正内容
- DelegateパターンでAPIの結果を受け取るようにする
- 天気予報のViewControllerのdeinit時にログを出力
- テストを修正

## スクリーンショット
見た目に変更がないので省略します。