### PR TITLE
Session 12: Concurrency

### DIFF
--- a/ios-training-komori/Model/WeatherModel.swift
+++ b/ios-training-komori/Model/WeatherModel.swift
@@ -12,52 +12,23 @@ protocol WeatherProvider {
 
     func fetch(
         area: String,
-        date: Date,
-        completion: @escaping (Result<Weather, Error>) -> Void
-    )
-
-    func fetchWithOptionalClosure(
-        area: String,
-        date: Date,
-        completion: ((Result<Weather, Error>) -> Void)?
-    )
+        date: Date
+    ) async -> Result<Weather, Error>
 }
 
 final class WeatherModel: WeatherProvider {
 
     func fetch(
         area: String,
-        date: Date,
-        completion: @escaping (Result<Weather, Error>) -> Void
-    ) {
-        DispatchQueue.global().async { [self] in
-            do {
-                let requestJson = try encodeRequest(area: area, date: date)
-                let responseJson = try YumemiWeather.syncFetchWeather(requestJson)
-                let fetchedWeather = try decodeResponse(responseJson)
-
-                completion(.success(fetchedWeather))
-            } catch {
-                completion(.failure(error))
-            }
-        }
-    }
-
-    func fetchWithOptionalClosure(
-        area: String,
-        date: Date,
-        completion: ((Result<Weather, Error>) -> Void)? = nil
-    ) {
-        DispatchQueue.global().async { [self] in
-            do {
-                let requestJson = try encodeRequest(area: area, date: date)
-                let responseJson = try YumemiWeather.syncFetchWeather(requestJson)
-                let fetchedWeather = try decodeResponse(responseJson)
-
-                completion?(.success(fetchedWeather))
-            } catch {
-                completion?(.failure(error))
-            }
+        date: Date
+    ) async -> Result<Weather, Error> {
+        do {
+            let requestJson = try encodeRequest(area: area, date: date)
+            let responseJson = try YumemiWeather.syncFetchWeather(requestJson)
+            let fetchedWeather = try decodeResponse(responseJson)
+            return .success(fetchedWeather)
+        } catch {
+            return .failure(error)
         }
     }
 }

--- a/ios-training-komori/View/Weather/WeatherViewController.swift
+++ b/ios-training-komori/View/Weather/WeatherViewController.swift
@@ -174,32 +174,17 @@ private extension WeatherViewController {
     func reload() {
         startLoadingIndicator()
 
-        weatherProvider.fetch(area: area, date: Date()) { [weak self] result in
-            DispatchQueue.main.async {
-                switch result {
-                case let .success(weather):
-                    self?.updateViews(with: weather)
-                case let .failure(error):
-                    self?.showAlert(for: error)
-                }
+        Task {
+            let result = await weatherProvider.fetch(area: area, date: Date())
 
-                self?.stopLoadingIndicator()
+            switch result {
+            case .success(let weather):
+                updateViews(with: weather)
+            case .failure(let error):
+                showAlert(for: error)
             }
+
+            stopLoadingIndicator()
         }
-
-
-//        // Fetch weather with optional closure
-//        weatherProvider.fetchWithOptionalClosure(area: area, date: Date()) { [weak self] result in
-//            DispatchQueue.main.async {
-//                switch result {
-//                case let .success(weather):
-//                    self?.updateViews(with: weather)
-//                case let .failure(error):
-//                    self?.showAlert(for: error)
-//                }
-//
-//                self?.stopLoadingIndicator()
-//            }
-//        }
     }
 }

--- a/ios-training-komoriTests/GeneratedMocks.swift
+++ b/ios-training-komoriTests/GeneratedMocks.swift
@@ -41,39 +41,19 @@ import YumemiWeather
     
     
     
-     func fetch(area: String, date: Date, completion: @escaping (Result<Weather, Error>) -> Void)  {
+     func fetch(area: String, date: Date) async -> Result<Weather, Error> {
         
-    return cuckoo_manager.call(
+    return await cuckoo_manager.call(
     """
-    fetch(area: String, date: Date, completion: @escaping (Result<Weather, Error>) -> Void)
+    fetch(area: String, date: Date) async -> Result<Weather, Error>
     """,
-            parameters: (area, date, completion),
-            escapingParameters: (area, date, completion),
+            parameters: (area, date),
+            escapingParameters: (area, date),
             superclassCall:
                 
                 Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 ,
-            defaultCall: __defaultImplStub!.fetch(area: area, date: date, completion: completion))
-        
-    }
-    
-    
-    
-    
-    
-     func fetchWithOptionalClosure(area: String, date: Date, completion: ((Result<Weather, Error>) -> Void)?)  {
-        
-    return cuckoo_manager.call(
-    """
-    fetchWithOptionalClosure(area: String, date: Date, completion: ((Result<Weather, Error>) -> Void)?)
-    """,
-            parameters: (area, date, completion),
-            escapingParameters: (area, date, completion),
-            superclassCall:
-                
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                ,
-            defaultCall: __defaultImplStub!.fetchWithOptionalClosure(area: area, date: date, completion: completion))
+            defaultCall: await __defaultImplStub!.fetch(area: area, date: date))
         
     }
     
@@ -89,22 +69,11 @@ import YumemiWeather
         
         
         
-        func fetch<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(area: M1, date: M2, completion: M3) -> Cuckoo.ProtocolStubNoReturnFunction<(String, Date, (Result<Weather, Error>) -> Void)> where M1.MatchedType == String, M2.MatchedType == Date, M3.MatchedType == (Result<Weather, Error>) -> Void {
-            let matchers: [Cuckoo.ParameterMatcher<(String, Date, (Result<Weather, Error>) -> Void)>] = [wrap(matchable: area) { $0.0 }, wrap(matchable: date) { $0.1 }, wrap(matchable: completion) { $0.2 }]
+        func fetch<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(area: M1, date: M2) -> Cuckoo.ProtocolStubFunction<(String, Date), Result<Weather, Error>> where M1.MatchedType == String, M2.MatchedType == Date {
+            let matchers: [Cuckoo.ParameterMatcher<(String, Date)>] = [wrap(matchable: area) { $0.0 }, wrap(matchable: date) { $0.1 }]
             return .init(stub: cuckoo_manager.createStub(for: MockWeatherProvider.self, method:
     """
-    fetch(area: String, date: Date, completion: @escaping (Result<Weather, Error>) -> Void)
-    """, parameterMatchers: matchers))
-        }
-        
-        
-        
-        
-        func fetchWithOptionalClosure<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.OptionalMatchable>(area: M1, date: M2, completion: M3) -> Cuckoo.ProtocolStubNoReturnFunction<(String, Date, ((Result<Weather, Error>) -> Void)?)> where M1.MatchedType == String, M2.MatchedType == Date, M3.OptionalMatchedType == ((Result<Weather, Error>) -> Void) {
-            let matchers: [Cuckoo.ParameterMatcher<(String, Date, ((Result<Weather, Error>) -> Void)?)>] = [wrap(matchable: area) { $0.0 }, wrap(matchable: date) { $0.1 }, wrap(matchable: completion) { $0.2 }]
-            return .init(stub: cuckoo_manager.createStub(for: MockWeatherProvider.self, method:
-    """
-    fetchWithOptionalClosure(area: String, date: Date, completion: ((Result<Weather, Error>) -> Void)?)
+    fetch(area: String, date: Date) async -> Result<Weather, Error>
     """, parameterMatchers: matchers))
         }
         
@@ -128,23 +97,11 @@ import YumemiWeather
         
         
         @discardableResult
-        func fetch<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.Matchable>(area: M1, date: M2, completion: M3) -> Cuckoo.__DoNotUse<(String, Date, (Result<Weather, Error>) -> Void), Void> where M1.MatchedType == String, M2.MatchedType == Date, M3.MatchedType == (Result<Weather, Error>) -> Void {
-            let matchers: [Cuckoo.ParameterMatcher<(String, Date, (Result<Weather, Error>) -> Void)>] = [wrap(matchable: area) { $0.0 }, wrap(matchable: date) { $0.1 }, wrap(matchable: completion) { $0.2 }]
+        func fetch<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable>(area: M1, date: M2) -> Cuckoo.__DoNotUse<(String, Date), Result<Weather, Error>> where M1.MatchedType == String, M2.MatchedType == Date {
+            let matchers: [Cuckoo.ParameterMatcher<(String, Date)>] = [wrap(matchable: area) { $0.0 }, wrap(matchable: date) { $0.1 }]
             return cuckoo_manager.verify(
     """
-    fetch(area: String, date: Date, completion: @escaping (Result<Weather, Error>) -> Void)
-    """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
-        }
-        
-        
-        
-        
-        @discardableResult
-        func fetchWithOptionalClosure<M1: Cuckoo.Matchable, M2: Cuckoo.Matchable, M3: Cuckoo.OptionalMatchable>(area: M1, date: M2, completion: M3) -> Cuckoo.__DoNotUse<(String, Date, ((Result<Weather, Error>) -> Void)?), Void> where M1.MatchedType == String, M2.MatchedType == Date, M3.OptionalMatchedType == ((Result<Weather, Error>) -> Void) {
-            let matchers: [Cuckoo.ParameterMatcher<(String, Date, ((Result<Weather, Error>) -> Void)?)>] = [wrap(matchable: area) { $0.0 }, wrap(matchable: date) { $0.1 }, wrap(matchable: completion) { $0.2 }]
-            return cuckoo_manager.verify(
-    """
-    fetchWithOptionalClosure(area: String, date: Date, completion: ((Result<Weather, Error>) -> Void)?)
+    fetch(area: String, date: Date) async -> Result<Weather, Error>
     """, callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
         }
         
@@ -162,16 +119,8 @@ import YumemiWeather
     
     
     
-     func fetch(area: String, date: Date, completion: @escaping (Result<Weather, Error>) -> Void)   {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
-    }
-    
-    
-    
-    
-    
-     func fetchWithOptionalClosure(area: String, date: Date, completion: ((Result<Weather, Error>) -> Void)?)   {
-        return DefaultValueRegistry.defaultValue(for: (Void).self)
+     func fetch(area: String, date: Date) async -> Result<Weather, Error>  {
+        return DefaultValueRegistry.defaultValue(for: (Result<Weather, Error>).self)
     }
     
     

--- a/ios-training-komoriTests/WeatherViewControllerTests.swift
+++ b/ios-training-komoriTests/WeatherViewControllerTests.swift
@@ -31,122 +31,147 @@ final class WeatherViewControllerTests: XCTestCase {
         weatherViewController = nil
     }
 
-    func testWeatherGetsReloadedOnReloadButtonTapped() {
+    func testWeatherGetsReloadedOnReloadButtonTapped() async {
         // Given
-        stub(mockWeatherProvider) { stub in
-            when(stub.fetch(area: any(), date: any(), completion: any())).thenDoNothing()
-        }
-
-        // When
-        weatherViewController.loadViewIfNeeded()
-        weatherViewController.onReloadButtonTapped(UIButton())
-
-        // Then
-        verify(mockWeatherProvider).fetch(area: any(), date: any(), completion: any())
-    }
-
-    func testSunnyImageIsSetIfSunny() {
-        // Given
+        let expectation = XCTestExpectation(description: "Fetch method should be called")
         let weather = Weather(
             condition: .sunny,
             minTemperature: 0,
             maxTemperature: 0
         )
+        let result = Result<Weather, Error>.success(weather)
         stub(mockWeatherProvider) { stub in
-            when(stub.fetch(area: any(), date: any(), completion: any())).then { _, _, completion in
-                completion(.success(weather))
+            when(stub.fetch(area: any(), date: any())).then { _, _ in
+                expectation.fulfill()
+                return result
             }
         }
 
         // When
-        weatherViewController.loadViewIfNeeded()
-        weatherViewController.onReloadButtonTapped(UIButton())
+        await MainActor.run {
+            weatherViewController.loadViewIfNeeded()
+            weatherViewController.onReloadButtonTapped(UIButton())
+        }
 
         // Then
-        let expectation = XCTestExpectation(description: "Weather image should be updated to 'img_sunny")
-        DispatchQueue.main.async {
-            XCTAssertEqual(self.weatherViewController.weatherImage.image, UIImage(named: "img_sunny"))
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 5)
+        await fulfillment(of: [expectation], timeout: 5)
+        verify(mockWeatherProvider).fetch(area: any(), date: any())
     }
 
-    func testCloudyImageIsSetIfCloudy() {
+    func testSunnyImageIsSetIfSunny() async {
         // Given
+        let expectation = XCTestExpectation(description: "Weather image should be updated to img_sunny")
+        let weather = Weather(
+            condition: .sunny,
+            minTemperature: 0,
+            maxTemperature: 0
+        )
+        let result = Result<Weather, Error>.success(weather)
+        stub(mockWeatherProvider) { stub in
+            when(stub.fetch(area: any(), date: any())).then { _, _ in
+                expectation.fulfill()
+                return result
+            }
+        }
+
+        // When
+        await MainActor.run {
+            weatherViewController.loadViewIfNeeded()
+            weatherViewController.onReloadButtonTapped(UIButton())
+        }
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 5)
+        await MainActor.run {
+            XCTAssertEqual(self.weatherViewController.weatherImage.image, UIImage(named: "img_sunny"))
+        }
+    }
+
+    func testCloudyImageIsSetIfCloudy() async {
+        // Given
+        let expectation = XCTestExpectation(description: "Weather image should be updated to img_cloudy")
         let weather = Weather(
             condition: .cloudy,
             minTemperature: 0,
             maxTemperature: 0
         )
+        let result = Result<Weather, Error>.success(weather)
         stub(mockWeatherProvider) { stub in
-            when(stub.fetch(area: any(), date: any(), completion: any())).then { _, _, completion in
-                completion(.success(weather))
+            when(stub.fetch(area: any(), date: any())).then { _, _ in
+                expectation.fulfill()
+                return result
             }
         }
 
         // When
-        weatherViewController.loadViewIfNeeded()
-        weatherViewController.onReloadButtonTapped(UIButton())
+        await MainActor.run {
+            weatherViewController.loadViewIfNeeded()
+            weatherViewController.onReloadButtonTapped(UIButton())
+        }
 
         // Then
-        let expectation = XCTestExpectation(description: "Weather image should be updated to 'img_cloudy")
-        DispatchQueue.main.async {
+        await fulfillment(of: [expectation], timeout: 5)
+        await MainActor.run {
             XCTAssertEqual(self.weatherViewController.weatherImage.image, UIImage(named: "img_cloudy"))
-            expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 5)
     }
 
-    func testRainyImageIsSetIfRainy() {
+    func testRainyImageIsSetIfRainy() async {
         // Given
+        let expectation = XCTestExpectation(description: "Weather image should be updated to img_rainy")
         let weather = Weather(
             condition: .rainy,
             minTemperature: 0,
             maxTemperature: 0
         )
+        let result = Result<Weather, Error>.success(weather)
         stub(mockWeatherProvider) { stub in
-            when(stub.fetch(area: any(), date: any(), completion: any())).then { _, _, completion in
-                completion(.success(weather))
+            when(stub.fetch(area: any(), date: any())).then { _, _ in
+                expectation.fulfill()
+                return result
             }
         }
 
         // When
-        weatherViewController.loadViewIfNeeded()
-        weatherViewController.onReloadButtonTapped(UIButton())
+        await MainActor.run {
+            weatherViewController.loadViewIfNeeded()
+            weatherViewController.onReloadButtonTapped(UIButton())
+        }
 
         // Then
-        let expectation = XCTestExpectation(description: "Weather image should be updated to 'img_rainy")
-        DispatchQueue.main.async {
+        await fulfillment(of: [expectation], timeout: 5)
+        await MainActor.run {
             XCTAssertEqual(self.weatherViewController.weatherImage.image, UIImage(named: "img_rainy"))
-            expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 5)
     }
 
-    func testTemperatureLabelsAreCorrectlySet() {
+    func testTemperatureLabelsAreCorrectlySet() async {
         // Given
+        let expectation = XCTestExpectation(description: "Temperature labels should be updated to -10 / 10")
         let weather = Weather(
             condition: .sunny,
             minTemperature: -10,
             maxTemperature: 10
         )
+        let result = Result<Weather, Error>.success(weather)
         stub(mockWeatherProvider) { stub in
-            when(stub.fetch(area: any(), date: any(), completion: any())).then { _, _, completion in
-                completion(.success(weather))
+            when(stub.fetch(area: any(), date: any())).then { _, _ in
+                expectation.fulfill()
+                return result
             }
         }
 
         // When
-        weatherViewController.loadViewIfNeeded()
-        weatherViewController.onReloadButtonTapped(UIButton())
+        await MainActor.run {
+            weatherViewController.loadViewIfNeeded()
+            weatherViewController.onReloadButtonTapped(UIButton())
+        }
 
         // Then
-        let expectation = XCTestExpectation(description: "Temperature labels should be updated to -10 / 10")
-        DispatchQueue.main.async {
+        await fulfillment(of: [expectation], timeout: 5)
+        await MainActor.run {
             XCTAssertEqual(self.weatherViewController.minTemperatureLabel.text, "-10")
             XCTAssertEqual(self.weatherViewController.maxTemperatureLabel.text, "10")
-            expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 5)
     }
 }


### PR DESCRIPTION
[Session 12: Concurrency](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Concurrency.md)の実装です。

## 修正内容
- APIの結果をConcurrencyで受け取るように変更
- テストを修正

## スクリーンショット
見た目に変更がないので省略します。